### PR TITLE
Window open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - BROWSER=firefox BVER=stable BROWSERSTACK=true
     - BROWSER=ie BVER=11  SAUCELABS=true
     - BROWSER=ie BVER=10  SAUCELABS=true
-    - BROWSER=chrome  BVER=stable BROWSERSTACK=true
+    - BROWSER=chrome  BVER=stable
   global:
   - TRAVIS=true
   - PORT=5000

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,16 @@ services:
 sudo: false
 matrix:
   fast_finish: true
+
+  allow_failures:
+    - env: BROWSER=chrome  BVER=beta
 env:
   matrix:
+    - BROWSER=chrome  BVER=stable
+    - BROWSER=chrome  BVER=beta
     - BROWSER=firefox BVER=stable BROWSERSTACK=true
     - BROWSER=ie BVER=11  SAUCELABS=true
     - BROWSER=ie BVER=10  SAUCELABS=true
-    - BROWSER=chrome  BVER=stable
   global:
   - TRAVIS=true
   - PORT=5000

--- a/tests/e2e/scenarios.js
+++ b/tests/e2e/scenarios.js
@@ -420,7 +420,7 @@ describe('OpenTok Meet App', function() {
       var firstBrowserText = element(by.css('.CodeMirror-code pre .cm-comment'));
       expect(firstBrowserText.isPresent()).toBe(true);
       browser.sleep(2000);
-      browser.actions().mouseDown(firstBrowserText).perform();
+      browser.actions().mouseDown(firstBrowserText).mouseUp(firstBrowserText).perform();
       browser.actions().sendKeys('foo').sendKeys('bar').perform();
       browser.wait(function () {
         return firstBrowserText.getInnerHtml().then(function (innerHTML) {
@@ -445,7 +445,8 @@ describe('OpenTok Meet App', function() {
       var secondBrowserText = element(by.css('.CodeMirror-code pre span.cm-comment'));
       expect(secondBrowserText.isPresent()).toBe(true);
       browser.sleep(2000);
-      browser.actions().mouseMove(secondBrowserText).mouseDown(secondBrowserText).perform();
+      browser.actions().mouseMove(secondBrowserText).mouseDown(secondBrowserText)
+        .mouseUp(secondBrowserText).perform();
       browser.actions().sendKeys('hello').sendKeys('world').perform();
       var secondInnerHTML;
       browser.wait(function () {

--- a/tests/e2e/scenarios.js
+++ b/tests/e2e/scenarios.js
@@ -430,8 +430,10 @@ describe('OpenTok Meet App', function() {
       });
 
       describe('subscriber buttons', function () {
+        var secondSubscriber;
         beforeEach(function (done) {
           switchToBrowser(2);
+          secondSubscriber = element(by.css('ot-subscriber'));
           // Move the publisher out of the way
           browser.driver.executeScript('$(\'#facePublisher\').css({top:200, left:0});')
             .then(function () {
@@ -444,31 +446,30 @@ describe('OpenTok Meet App', function() {
         });
 
         iit('change size button works', function () {
-          var subscriber = element(by.css('ot-subscriber'));
-          expect(subscriber.getAttribute('class')).not.toContain('OT_big');
-          var resizeBtn = subscriber.element(by.css('.resize-btn'));
+          expect(secondSubscriber.getAttribute('class')).not.toContain('OT_big');
+          var resizeBtn = secondSubscriber.element(by.css('.resize-btn'));
           expect(resizeBtn.getAttribute('title')).toBe('Enlarge');
           resizeBtn.click();
           browser.wait(function () {
-            return subscriber.getAttribute('class').then(function (className) {
+            return secondSubscriber.getAttribute('class').then(function (className) {
               return className.indexOf('OT_big') > -1;
             });
           }, 5000);
           expect(resizeBtn.getAttribute('title')).toBe('Shrink');
           if (browser.browserName === 'internet explorer') {
             // For some reason you need to focus the second browser again
-            browser.actions().mouseDown(subscriber).perform();
+            browser.actions().mouseDown(secondSubscriber).perform();
           }
           resizeBtn.click();
           browser.wait(function () {
-            return subscriber.getAttribute('class').then(function (className) {
+            return secondSubscriber.getAttribute('class').then(function (className) {
               return className.indexOf('OT_big') === -1;
             });
           }, 5000);
           expect(resizeBtn.getAttribute('title')).toBe('Enlarge');
         });
 
-        it('muteVideo button works', function () {
+        iit('muteVideo button works', function () {
           var muteBtn = secondSubscriber.element(by.css('mute-video'));
           expect(muteBtn.element(by.css('.ion-ios7-close')).isPresent()).toBe(true);
           muteBtn.click();
@@ -479,7 +480,7 @@ describe('OpenTok Meet App', function() {
           expect(secondSubscriber.getAttribute('class')).not.toContain('OT_audio-only');
         });
 
-        it('restrictFramerate button toggles the icon and the title', function () {
+        iit('restrictFramerate button toggles the icon and the title', function () {
           var restrictFramerateBtn = secondSubscriber.element(by.css('.restrict-framerate-btn'));
           expect(restrictFramerateBtn.getAttribute('class')).toContain('ion-ios7-speedometer');
           expect(restrictFramerateBtn.getAttribute('title')).toBe('Restrict Framerate');
@@ -492,16 +493,16 @@ describe('OpenTok Meet App', function() {
           expect(restrictFramerateBtn.getAttribute('title')).toBe('Restrict Framerate');
         });
 
-        it('stats button works', function() {
-          var showStatsInfo = secondBrowser.element(by.css('.show-stats-info'));
+        iit('stats button works', function() {
+          var showStatsInfo = secondSubscriber.element(by.css('.show-stats-info'));
           var statsButton = secondSubscriber.element(by.css('.show-stats-btn'));
           expect(showStatsInfo.isDisplayed()).toBe(false);
           statsButton.click();
-          secondBrowser.wait(function() {
+          browser.wait(function() {
             return showStatsInfo.isDisplayed();
           }, 2000);
           expect(showStatsInfo.isDisplayed()).toBe(true);
-          secondBrowser.wait(function() {
+          browser.wait(function() {
             return showStatsInfo.getInnerHtml().then(function(innerHTML) {
               var statsRegexp = new RegExp('Resolution: \\d+x\\d+<br>.*' +
                 'Audio Packet Loss: \\d\\d?\\.\\d\\d%<br>' +
@@ -519,8 +520,8 @@ describe('OpenTok Meet App', function() {
           beforeEach(function () {
             element(by.css('#showscreen')).click();
           });
-          it('subscribes to the screen and it is big', function () {
-            var subscriberVideo = secondBrowser.element(by.css(
+          iit('subscribes to the screen and it is big', function () {
+            var subscriberVideo = element(by.css(
               'ot-subscriber.OT_big:not(.OT_loading) video'));
             browser.wait(function () {
               return subscriberVideo.isPresent();
@@ -530,34 +531,35 @@ describe('OpenTok Meet App', function() {
       }
 
       describe('using the collaborative editor', function () {
-        var firstShowEditorBtn, secondShowEditorBtn;
+        var secondShowEditorBtn;
         beforeEach(function () {
-          firstShowEditorBtn = element(by.css('#showEditorBtn'));
-          secondShowEditorBtn = secondBrowser.element(by.css('#showEditorBtn'));
+          switchToBrowser(2);
+          secondShowEditorBtn = element(by.css('#showEditorBtn'));
           secondShowEditorBtn.click();
           browser.wait(function () {
-            return secondBrowser.element(by.css('ot-editor .opentok-editor')).isDisplayed();
+            return element(by.css('ot-editor .opentok-editor')).isDisplayed();
           }, 10000);
         });
 
         afterEach(function () {
-          firstShowEditorBtn = secondShowEditorBtn = null;
+          secondShowEditorBtn = null;
         });
 
-        it('contains the default text', function () {
-          var defaultText = secondBrowser.element(by.css('.CodeMirror-code pre .cm-comment'));
+        iit('contains the default text', function () {
+          var defaultText = element(by.css('.CodeMirror-code pre .cm-comment'));
           expect(defaultText.isPresent()).toBe(true);
           expect(defaultText.getInnerHtml()).toBe('// Write code here');
         });
 
         describe('when you enter text on the second browser', function () {
           beforeEach(function () {
-            var inputText = secondBrowser.element(by.css('.CodeMirror-code pre .cm-comment'));
-            secondBrowser.actions().mouseDown(inputText).perform();
-            secondBrowser.actions().sendKeys('hello world').perform();
+            var inputText = element(by.css('.CodeMirror-code pre .cm-comment'));
+            browser.actions().mouseDown(inputText).perform();
+            browser.actions().sendKeys('hello world').perform();
           });
 
-          it('makes the red dot blink for the first browser', function () {
+          iit('makes the red dot blink for the first browser', function () {
+            switchToBrowser(1);
             browser.wait(function () {
               return element(by.css('body.mouse-move .unread-indicator.unread #showEditorBtn'))
                 .isPresent();

--- a/tests/e2e/scenarios.js
+++ b/tests/e2e/scenarios.js
@@ -421,8 +421,12 @@ describe('OpenTok Meet App', function() {
       expect(firstBrowserText.isPresent()).toBe(true);
       browser.sleep(2000);
       browser.actions().mouseDown(firstBrowserText).perform();
-      browser.actions().sendKeys('foo bar').perform();
-      expect(firstBrowserText.getInnerHtml()).toContain('foo bar');
+      browser.actions().sendKeys('foo').sendKeys('bar').perform();
+      browser.wait(function () {
+        return firstBrowserText.getInnerHtml().then(function (innerHTML) {
+          return innerHTML.indexOf('bar') > -1;
+        });
+      }, 2000);
 
       openSecondWindow();
       switchToWindow(2);
@@ -442,22 +446,25 @@ describe('OpenTok Meet App', function() {
       expect(secondBrowserText.isPresent()).toBe(true);
       browser.sleep(2000);
       browser.actions().mouseMove(secondBrowserText).mouseDown(secondBrowserText).perform();
-      browser.actions().sendKeys('baz').sendKeys('hello world').perform();
-      expect(firstBrowserText.getInnerHtml()).toContain('hello world');
-
-      secondBrowserText.getInnerHtml().then(function (secondInnerHTML) {
-        browser.sleep(2000);
-
-        closeSecondWindow().then(function () {
-          switchToWindow(1);
-          // wait for text to show up in the first browser
-          browser.wait(function () {
-            return firstBrowserText.getInnerHtml().then(function (innerHTML) {
-              return innerHTML === secondInnerHTML;
-            });
-          }, 10000);
-          done();
+      browser.actions().sendKeys('hello').sendKeys('world').perform();
+      var secondInnerHTML;
+      browser.wait(function () {
+        return secondBrowserText.getInnerHtml().then(function (innerHTML) {
+          secondInnerHTML = innerHTML;
+          return innerHTML.indexOf('world') > -1;
         });
+      }, 2000);
+      browser.sleep(2000);
+
+      closeSecondWindow().then(function () {
+        switchToWindow(1);
+        // wait for text to show up in the first browser
+        browser.wait(function () {
+          return firstBrowserText.getInnerHtml().then(function (innerHTML) {
+            return innerHTML === secondInnerHTML;
+          });
+        }, 10000);
+        done();
       });
     });
   });
@@ -468,7 +475,7 @@ describe('OpenTok Meet App', function() {
       openSecondWindow();
     });
     afterEach(function (done) {
-      closeSecondWindow.then(done);
+      closeSecondWindow().then(done);
     });
 
     describe('subscribing to one another', function () {
@@ -682,7 +689,7 @@ describe('OpenTok Meet App', function() {
               openSecondWindow();
             });
             afterEach(function(done) {
-              closeSecondWindow.then(done);
+              closeSecondWindow().then(done);
             });
             it('subscribes to the screen and it is big', function () {
               var subscriberVideo = element(by.css(

--- a/tests/e2e/scenarios.js
+++ b/tests/e2e/scenarios.js
@@ -13,6 +13,7 @@ describe('OpenTok Meet App', function() {
     browser.getCapabilities().then(function (cap) {
       browser.browserName = cap.caps_.browserName;
       roomURL = browser.browserName === 'firefox' ? roomName + '?fakeDevices=true' : roomName;
+      roomURL = '/' + roomURL;
     });
   });
 
@@ -607,9 +608,11 @@ describe('OpenTok Meet App', function() {
       if (browser.params.testScreenSharing) {
         describe('sharing the screen', function () {
           beforeEach(function () {
+            switchToWindow(2);
             element(by.css('#showscreen')).click();
           });
           it('subscribes to the screen and it is big', function () {
+            switchToWindow(1);
             var subscriberVideo = element(by.css(
               'ot-subscriber.OT_big:not(.OT_loading) video'));
             browser.wait(function () {
@@ -688,6 +691,7 @@ describe('OpenTok Meet App', function() {
           describe('a subscriber', function () {
             beforeEach(function () {
               openSecondWindow();
+              switchToWindow(2);
             });
             afterEach(function(done) {
               closeSecondWindow().then(done);

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
       version: process.env.BVER
     }
   };
-  var browser = process.env.BROWSER;
+  var browser = process.env.BROWSER || 'chrome';
   config.set({
 
     basePath: '../',

--- a/tests/protractor.conf.js
+++ b/tests/protractor.conf.js
@@ -77,27 +77,29 @@ switch(process.env.BROWSER) {
       ],
 
       capabilities: {
-        'browserstack.user' : process.env.BROWSERSTACK_USERNAME,
-        'browserstack.key' : process.env.BROWSERSTACK_KEY,
-        'browserstack.local' : 'true',
         'browserName': 'chrome',
-        'os' : 'OS X',
-        'os_version' : 'Yosemite',
         'chromeOptions': {
-          'args': ['use-fake-device-for-media-stream', 'use-fake-ui-for-media-stream']
+          'args': ['auto-select-desktop-capture-source="Entire screen"',
+            'use-fake-device-for-media-stream',
+            'use-fake-ui-for-media-stream'],
+          'binary': process.env.CHROME_BIN
         }
       },
 
-      seleniumAddress: 'http://hub.browserstack.com/wd/hub',
+      directConnect: true,
 
       baseUrl: 'http://localhost:5000/',
+
+      params: {
+        testScreenSharing: false
+      },
 
       framework: 'jasmine',
 
       jasmineNodeOpts: {
         defaultTimeoutInterval: 60000
       }
-  };
+    };
   break;
 }
 exports.config = config;


### PR DESCRIPTION
Using `window.open` to spawn new windows instead of `forkNewDriverInstance`. Was finding that ChromeDriver on Selenium wasn't playing nicely with `forkNewDriverInstance`. It also means that you don't need 2 VMs on BrowserStack or SauceLabs to run the tests.