### PR TITLE
Update to latest hiredis-node version to support newer versions of Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "express": "3.1.x",
     "gulp": "~3.5.5",
     "gulp-bower": "~0.0.3",
-    "hiredis": "~0.1.16",
+    "hiredis": "~0.4.1",
     "opentok": "^2.2.3",
     "redis": "~0.10.1"
   },


### PR DESCRIPTION
I wasn't able to run opentok-meet with node v4.2.2, updating hiredis fixed it and caused no new issues that I could see.