### PR TITLE
Using media.navigator.streams.fake flag instead of mocking out getuse…

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -67,8 +67,7 @@ module.exports = function (app, config, redis, ot, redirectSSL) {
   app.get('/:room', function(req, res) {
     var room = req.param('room'),
       apiKey = req.param('apiKey'),
-      secret = req.param('secret'),
-      fakeDevices = req.param('fakeDevices');
+      secret = req.param('secret');
     res.format({
       json: function() {
         var goToRoom = function(err, sessionId, apiKey, secret) {
@@ -112,7 +111,6 @@ module.exports = function (app, config, redis, ot, redirectSSL) {
         }
         res.render('room', {
           room: room,
-          fakeDevices: fakeDevices,
           chromeExtensionId: config.chromeExtensionId
         });
       }

--- a/tests/e2e/scenarios.js
+++ b/tests/e2e/scenarios.js
@@ -12,7 +12,7 @@ describe('OpenTok Meet App', function() {
     }
     browser.getCapabilities().then(function (cap) {
       browser.browserName = cap.caps_.browserName;
-      roomURL = browser.browserName === 'firefox' ? roomName + '?fakeDevices=true' : roomName;
+      roomURL = roomName;
       roomURL = '/' + roomURL;
     });
   });

--- a/tests/firefox-helper.js
+++ b/tests/firefox-helper.js
@@ -10,6 +10,7 @@ exports.getFirefoxProfile = function() {
 
   var firefoxProfile = new FirefoxProfile();
   firefoxProfile.setPreference('media.navigator.permission.disabled', true);
+  firefoxProfile.setPreference('media.navigator.streams.fake', true);
   firefoxProfile.setPreference('media.getusermedia.screensharing.allowed_domains',
     'localhost,adam.local');
   firefoxProfile.encoded(function(encodedProfile) {

--- a/views/room.ejs
+++ b/views/room.ejs
@@ -14,18 +14,6 @@
         <link rel="stylesheet" href="/css/subscriber-stats.css" type="text/css" media="screen">
         <script src="/js/lib/jquery/dist/jquery.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="/js/lib/angular/angular.min.js" type="text/javascript" charset="utf-8"></script>
-        <script type="text/javascript">
-          if ('<%=fakeDevices%>' !== '') { // Set by protractor for testing Firefox
-            // Mock out mozGetUserMedia and force pass the fake:true contstraint
-            var oldGetUserMedia = navigator.mozGetUserMedia;
-            navigator.mozGetUserMedia = function(constraints) {
-              constraints.video = true;
-              constraints.audio = true;
-              constraints.fake = true;
-              oldGetUserMedia.apply(this, arguments);
-            };
-          }
-        </script>
         <script src="//static.opentok.com/v2/js/opentok.js"></script>
         <script src="/js/lib/opentok-layout-js/opentok-layout.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="/js/lib/opentok-angular/opentok-angular.js" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
…rmedia