### PR TITLE
Try adding esr firefox version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - BROWSER=ie BVER=10  SAUCELABS=true
     - BROWSER=chrome  BVER=beta
     - BROWSER=firefox BVER=beta
+    - BROWSER=firefox BVER=esr
   global:
   - TRAVIS=true
   - PORT=5000


### PR DESCRIPTION
It's the extended support release which is 45 and hopefully still works with webdriver. I noticed that that's what the adapter.js tests use
https://travis-ci.org/webrtc/adapter