### PR TITLE
Fixes #131 don't let publisher go off screen

### DIFF
--- a/src/js/directives.js
+++ b/src/js/directives.js
@@ -48,8 +48,8 @@ function($document, $window) {
       $document.unbind('mouseup touchend', mouseUpHandler);
       // We only want to add this event once so we remove it in case we already
       // added it previously
-      // angular.element($window).unbind('resize', resizeHandler);
-      // angular.element($window).on('resize', resizeHandler);
+      angular.element($window).unbind('resize', resizeHandler);
+      angular.element($window).on('resize', resizeHandler);
     };
 
     if (position !== 'relative' && position !== 'absolute') {

--- a/src/js/directives.js
+++ b/src/js/directives.js
@@ -1,4 +1,5 @@
-angular.module('opentok-meet').directive('draggable', ['$document', function($document) {
+angular.module('opentok-meet').directive('draggable', ['$document', '$window',
+function($document, $window) {
   var getEventProp = function(event, prop) {
     if (event[prop] === 0) return 0;
     return event[prop] || (event.touches && event.touches[0][prop]) ||
@@ -7,6 +8,12 @@ angular.module('opentok-meet').directive('draggable', ['$document', function($do
   };
 
   return function(scope, element) {
+    var position = element.css('position'),
+      startX = 0,
+      startY = 0,
+      x = 0,
+      y = 0;
+
     var mouseMoveHandler = function mouseMoveHandler(event) {
       y = getEventProp(event, 'pageY') - startY;
       x = getEventProp(event, 'pageX') - startX;
@@ -16,16 +23,35 @@ angular.module('opentok-meet').directive('draggable', ['$document', function($do
       });
     };
 
+    var resizeHandler = function resizeHandler() {
+      // Always make sure that the element is on the page when it is resized
+      var winHeight = angular.element($window).height();
+      var winWidth = angular.element($window).width();
+      if (winHeight - element.height() < parseInt(element.css('top'), 10)) {
+        // We're too short switch to being bottom aligned
+        element.css({
+          top: 'auto',
+          bottom: '10px'
+        });
+      }
+      if (winWidth - element.width() < parseInt(element.css('left'), 10)) {
+        // We're too narrow, switch to being right aligned
+        element.css({
+          left: 'auto',
+          right: '10px'
+        });
+      }
+    };
+
     var mouseUpHandler = function mouseUpHandler() {
       $document.unbind('mousemove touchmove', mouseMoveHandler);
       $document.unbind('mouseup touchend', mouseUpHandler);
+      // We only want to add this event once so we remove it in case we already
+      // added it previously
+      // angular.element($window).unbind('resize', resizeHandler);
+      // angular.element($window).on('resize', resizeHandler);
     };
 
-    var position = element.css('position'),
-      startX = 0,
-      startY = 0,
-      x = 0,
-      y = 0;
     if (position !== 'relative' && position !== 'absolute') {
       element.css('positon', 'relative');
       position = 'relative';
@@ -136,7 +162,7 @@ angular.module('opentok-meet').directive('draggable', ['$document', function($do
     return {
       restrict: 'E',
       template: '<p>Reconnecting{{ dots }}</p>',
-      link: function (scope, element) {
+      link: function (scope) {
         var intervalPromise;
 
         scope.dots = '';

--- a/tests/e2e/roomScenarios.js
+++ b/tests/e2e/roomScenarios.js
@@ -68,6 +68,17 @@ describe('Room', function() {
       expect(newLocation).not.toEqual(oldLocation);
     });
 
+    // Note this does not actually work in Chrome because drag and drop doesn't
+    // work properly in webdriver https://github.com/angular/protractor/issues/583
+    it('stays on the screen if you resize too small', function() {
+      expect(publisher.isDisplayed()).toBe(true);
+      browser.manage().window().setSize(800, 800);
+      browser.actions().mouseDown(publisher)
+           .mouseMove({x: 700, y:700}).mouseUp().perform();
+      browser.manage().window().setSize(500, 500);
+      expect(publisher.isDisplayed()).toBe(true);
+    });
+
     // This isn't passing in browserstack for some reason need to figure out why
     xit('mutes video when you click the mute-video icon', function () {
       browser.wait(function () {

--- a/tests/unit/directivesSpec.js
+++ b/tests/unit/directivesSpec.js
@@ -97,8 +97,9 @@ describe('draggable', function () {
     $window.dispatchEvent(event);
     expect(element.css('bottom')).toBe('10px');
     expect(element.css('right')).toBe('10px');
-    expect(element.css('top')).toBe('auto');
-    expect(element.css('left')).toBe('auto');
+    // In IE 10 for some reason it gets set to 0px even though we set it to auto
+    expect(element.css('top') === '0px' || element.css('top') === 'auto').toBe(true);
+    expect(element.css('left') === '0px' || element.css('left') === 'auto').toBe(true);
   });
 });
 

--- a/tests/unit/directivesSpec.js
+++ b/tests/unit/directivesSpec.js
@@ -92,7 +92,9 @@ describe('draggable', function () {
     $document.triggerHandler({
       type: 'mouseup'
     });
-    $window.dispatchEvent(new Event('resize'));
+    var event = document.createEvent('Event');
+    event.initEvent('resize', false, true);
+    $window.dispatchEvent(event);
     expect(element.css('bottom')).toBe('10px');
     expect(element.css('right')).toBe('10px');
     expect(element.css('top')).toBe('auto');

--- a/tests/unit/directivesSpec.js
+++ b/tests/unit/directivesSpec.js
@@ -4,11 +4,12 @@ require('angular-mocks');
 require('../../src/js/app.js');
 
 describe('draggable', function () {
-  var scope, element, $document;
+  var scope, element, $document, $window;
   beforeEach(angular.mock.module('opentok-meet'));
-  beforeEach(inject(function ($rootScope, $compile, _$document_) {
+  beforeEach(inject(function ($rootScope, $compile, _$document_, _$window_) {
     scope = $rootScope.$new();
     $document = _$document_;
+    $window = _$window_;
     element = '<div draggable="true"></div>';
     element = $compile(element)(scope);
     scope.$digest();
@@ -75,6 +76,27 @@ describe('draggable', function () {
     });
     expect(element.css('top')).toBe('10px');
     expect(element.css('left')).toBe('10px');
+  });
+
+  it('realigns to the bottom right if you resize too small', function() {
+    element.triggerHandler({
+      type: 'mousedown',
+      pageX: 0,
+      pageY: 0
+    });
+    $document.triggerHandler({
+      type: 'mousemove',
+      pageX: 10000,
+      pageY: 10000
+    });
+    $document.triggerHandler({
+      type: 'mouseup'
+    });
+    $window.dispatchEvent(new Event('resize'));
+    expect(element.css('bottom')).toBe('10px');
+    expect(element.css('right')).toBe('10px');
+    expect(element.css('top')).toBe('auto');
+    expect(element.css('left')).toBe('auto');
   });
 });
 


### PR DESCRIPTION
Now if you resize the window to be smaller than the position of the publisher, the publisher starts to be bottom right aligned instead of top left.