### PR TITLE
Update angular version to 1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "angular": "^1.5.5",
+    "angular": "~1.6.0",
     "css-loader": "^0.23.1",
     "ejs": ">= 0.0.1",
     "express": "3.1.x",
@@ -39,7 +39,7 @@
     "protractor": "node_modules/.bin/protractor tests/protractor-chrome.conf.js"
   },
   "devDependencies": {
-    "angular-mocks": "^1.5.5",
+    "angular-mocks": "~1.6.0",
     "codeclimate-test-reporter": "0.0.4",
     "firefox-profile": "^0.3.9",
     "jasmine-core": "^2.2.0",

--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -50,15 +50,15 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
 
   var startArchiving = function() {
     $scope.archiving = true;
-    $http.post(baseURL + $scope.room + '/startArchive').success(function(response) {
-      if (response.error) {
+    $http.post(baseURL + $scope.room + '/startArchive').then(function(response) {
+      if (response.data.error) {
         $scope.archiving = false;
-        console.error('Failed to start archive', response.error);
+        console.error('Failed to start archive', response.data.error);
       } else {
-        $scope.archiveId = response.archiveId;
+        $scope.archiveId = response.data.archiveId;
       }
-    }).error(function(data) {
-      console.error('Failed to start archiving', data);
+    }).catch(function(response) {
+      console.error('Failed to start archiving', response);
       $scope.archiving = false;
     });
   };
@@ -67,15 +67,15 @@ angular.module('opentok-meet').controller('RoomCtrl', ['$scope', '$http', '$wind
     $scope.archiving = false;
     $http.post(baseURL + $scope.room + '/stopArchive', {
       archiveId: $scope.archiveId
-    }).success(function(response) {
-      if (response.error) {
-        console.error('Failed to stop archiving', response.error);
+    }).then(function(response) {
+      if (response.data.error) {
+        console.error('Failed to stop archiving', response.data.error);
         $scope.archiving = true;
       } else {
-        $scope.archiveId = response.archiveId;
+        $scope.archiveId = response.data.archiveId;
       }
-    }).error(function(data) {
-      console.error('Failed to stop archiving', data);
+    }).catch(function(response) {
+      console.error('Failed to stop archiving', response);
       $scope.archiving = true;
     });
   };

--- a/src/js/services.js
+++ b/src/js/services.js
@@ -1,14 +1,14 @@
 // Asynchronous fetching of the room. This is so that the mobile app can use the
 // same controller. It doesn't know the room straight away
-angular.module('opentok-meet').factory('RoomService', ['$q', '$http', 'baseURL', '$window', 'room',
-  function($q, $http, baseURL, $window, room) {
+angular.module('opentok-meet').factory('RoomService', ['$http', 'baseURL', '$window', 'room',
+  function($http, baseURL, $window, room) {
     return {
       getRoom: function() {
-        var deferred = $q.defer();
-        $http.get(baseURL + room).success(function(roomData) {
-          deferred.resolve(roomData);
+        return $http.get(baseURL + room).then(function(response) {
+          return response.data;
+        }).catch(function(response) {
+          return response.data;
         });
-        return deferred.promise;
       },
       changeRoom: function() {
         $window.location.href = baseURL;


### PR DESCRIPTION
1. We have to lock down angular to the minor version as they don't correctly use semver and have introduced breaking changes in 1.6
2. Fixed the breaking changes (deprecated $http's success/error functions)