### PR TITLE
Fix #162 remove unused code from being bundled

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "karma-sauce-launcher": "^0.2.14",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
+    "null-loader": "^0.1.1",
     "opentok-test-scripts": "^3.0.3",
     "protractor": "^4.0.9",
     "protractor-flake": "^2.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ module.exports = {
     devtool: 'source-map',
     module: {
         loaders: [
-            { test: /\.css$/, loader: 'style!css' }
+            { test: /\.css$/, loader: 'style!css' },
+            { test: /codemirror\/mode(?!.*(javascript|markdown)).*/, loader: 'null' }
         ]
     },
     plugins: [


### PR DESCRIPTION
This PR removes a bunch of syntax highlighting definitions for codemirror from being bundled.