### PR TITLE
Use Firefox 46.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 env:
   matrix:
     - BROWSER=chrome  BVER=stable
-    - BROWSER=firefox BVER=esr
+    - BROWSER=firefox BVER=46.0.1
     - BROWSER=ie BVER=11  SAUCELABS=true
     - BROWSER=ie BVER=10  SAUCELABS=true
     - BROWSER=firefox BVER=stable

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
     "null-loader": "^0.1.1",
-    "opentok-test-scripts": "^3.0.3",
+    "opentok-test-scripts": "^3.3.1",
     "protractor": "^4.0.9",
     "protractor-flake": "^2.1.2",
     "q": "^1.2.0",


### PR DESCRIPTION
Because I haven't got marionette driver working yet. For whatever reason I can get it to work locally but I can't get it to work properly on Travis. I couldn't figure out how to set the path to the Firefox binary which is a custom path in Travis using travis-multirunner. More details on https://github.com/aullman/opentok-textchat/pull/1