### PR TITLE
Allow Firefox to fail for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
     - os: linux
       env: BROWSER=ie BVER=11 SAUCELABS=true
     - os: linux
-      env: BROWSER=ie BVER=10 SAUCELABS=true
-    - os: linux
       env: BROWSER=firefox BVER=stable INTEGRATION_CMD=''
     - os: linux
       env: BROWSER=firefox BVER=beta INTEGRATION_CMD=''

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 
   include:
     - os: linux
-      env: BROWSER=chrome  BVER=59.0.3071.86
+      env: BROWSER=chrome  BVER=stable
     - os: linux
       env: BROWSER=firefox BVER=45.0.2
     - os: linux
@@ -42,15 +42,11 @@ matrix:
 
   allow_failures:
     - os: linux
-      env: BROWSER=firefox BVER=beta INTEGRATION_CMD=''
+      env: BROWSER=firefox BVER=45.0.2
     - os: linux
       env: BROWSER=chrome  BVER=beta
     - os: linux
-      env: BROWSER=firefox BVER=stable INTEGRATION_CMD=''
-    - os: osx
-      osx_image: xcode8.3
-      sudo: required
-      env: BROWSER=safari BVER=unstable INTEGRATION_CMD=''
+      env: BROWSER=firefox BVER=beta INTEGRATION_CMD=''
 
 env:
   global:


### PR DESCRIPTION
It's failing because Firefox 45 isn't supported anymore. So now the only browser running the full integration suite is Chrome.
Trying to run Chrome stable instead of 59 because it looks like beta is passing now.