### PR TITLE
Add extra condition to show "user joined" notification

### DIFF
--- a/src/js/notifications.js
+++ b/src/js/notifications.js
@@ -19,7 +19,8 @@ angular.module('opentok-meet').factory('NotificationService', ['$window', 'OTSes
         OTSession.on('init', notifyOnConnectionCreated);
       } else {
         OTSession.session.on('connectionCreated', (event) => {
-          if (!focused &&
+          const visible = $window.document.visibilityState === 'visible';
+          if ((!focused || !visible) &&
               event.connection.connectionId !== OTSession.session.connection.connectionId) {
             Push.create('New Participant', {
               body: 'Someone joined your meeting',


### PR DESCRIPTION
If you open the page and without clicking anything you go to other app, then you won't get the notification => I don't know how to solve this.
If you open the page and without clicking anything you go to other tab, then you won't get the notification => It should be fixed with this change because in that case visibilityState === 'hidden'.

(Disclaimer: Didn't test it inside opentok-meet but in my own app)